### PR TITLE
Correcting examples ahead of 5.4 release

### DIFF
--- a/oas/petstore/api-fd1d5a17b4a24768635fc1ca415b6f40.json
+++ b/oas/petstore/api-fd1d5a17b4a24768635fc1ca415b6f40.json
@@ -1,5 +1,6 @@
 {
-    "info": {
+   "oas":
+   { "info": {
       "title": "petstore",
       "version": "1.0.0"
     },
@@ -91,4 +92,5 @@
         "url": "https://petstore3.swagger.io/api/v3"
       }
     }
+  }
   }

--- a/repository.json
+++ b/repository.json
@@ -32,23 +32,6 @@
             "Renaming fields in UDG"
           ],
           "minTykVersion": "5.1"
-        },
-        {
-          "location": "graphql/star-wars",
-          "name": "Star Wars GQL API",
-          "description": "This GraphQL API retrieves all the Star Wars data you've ever wanted: Planets, Spaceships, Vehicles, People, Films and Species from all seven Star Wars films.",
-          "features": [
-            "Authorization Token"
-          ],
-          "minTykVersion": "5.4"
-        },
-        {
-          "location": "oas/petstore",
-          "name": "Petstore OAS HTTP API",
-          "description": "This is a sample Pet Store Server based on the OpenAPI 3.0 specification.",
-          "features": [
-          ],
-          "minTykVersion": "5.4"
         }
       ],
       "graphql": [
@@ -63,14 +46,6 @@
         }
       ],
       "oas": [
-        {
-          "location": "oas/petstore",
-          "name": "Petstore OAS HTTP API",
-          "description": "This is a sample Pet Store Server based on the OpenAPI 3.0 specification.",
-          "features": [
-          ],
-          "minTykVersion": "5.4"
-        }
       ]
     }
   }


### PR DESCRIPTION
- removed duplicated entries from repository.json
- removed oas example for repository.json - will be added once tyk-sync is updated, this will prevent displaying non-working example in the Dashboard
- corrected the oas example api def file - wrapping everything inside "oas" object